### PR TITLE
Fix melody extraction

### DIFF
--- a/src/melody_extraction/melody_extractor.py
+++ b/src/melody_extraction/melody_extractor.py
@@ -46,6 +46,8 @@ class MelodyExtractor:
         """
         audio = AudioData.from_file(input_path)
 
+        audio = AudioData(librosa.effects.trim(audio.array, top_db=10)[0], audio.sample_rate)  # type: ignore
+
         harmonic_audio, onset_times = self._harmonic_percussive_split(audio)
 
         t, pitch_midi = PitchDetector.detect(harmonic_audio, PitchDetectorConfig())

--- a/src/melody_extraction/note_collection_builder.py
+++ b/src/melody_extraction/note_collection_builder.py
@@ -100,11 +100,11 @@ class NoteCollectionBuilder:
         last_pitch_idx = nonnan[-1]
 
         unit_count = 0
-        for unit_start in range(
-            first_pitch_idx, last_pitch_idx, int(self._frames_per_unit)
-        ):
-            self._step(unit_count, unit_start)
+        unit_start = first_pitch_idx
+        while unit_start < last_pitch_idx:
+            self._step(unit_count, int(unit_start))
             unit_count += 1
+            unit_start += self._frames_per_unit
 
         # End the last note.
         if self._note_start is not None:

--- a/src/melody_extraction/pitch_detector.py
+++ b/src/melody_extraction/pitch_detector.py
@@ -34,9 +34,10 @@ class PitchDetector:
             fmin=librosa.note_to_hz("C3"),  # type: ignore
             fmax=librosa.note_to_hz("G6"),  # type: ignore
             sr=audio.sample_rate,
+            fill_na=np.nan
         )
         t = librosa.times_like(f0, sr=audio.sample_rate)  # type: ignore
-        f0[voiced_probs < 0.5] = np.nan
+        f0[voiced_probs < 0.6] = np.nan
 
         return t, f0
 

--- a/src/melody_extraction/util.py
+++ b/src/melody_extraction/util.py
@@ -8,4 +8,7 @@ def mode(arr: NDArray[np.float16]) -> NDArray[np.float16] | None:
         return None
     counts = np.bincount(int_arr)
     max_count = np.max(counts)
+    nan_count = arr[np.isnan(arr)].size
+    if nan_count >= max_count:
+        return None
     return np.argwhere(counts == max_count).flatten().astype(np.float16)


### PR DESCRIPTION
- Frames per unit are floats, not integers. They're not big enough for the rounding to be negligible, and this caused an increasing offset as the input is processed. Fixed this
- Added a step to trim the audio to remove silence that could cause artifacts before and after the melody.